### PR TITLE
C# integratedTerminal

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,8 +47,9 @@
             "program": "${workspaceFolder}/csharp/bin/Debug/net6.0/csharp.dll",
             "args": [],
             "cwd": "${workspaceFolder}/csharp",
-            "console": "internalConsole",
-            "stopAtEntry": false
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
         },
     ],
     "version": "2.0.0"


### PR DESCRIPTION
# 概要

`internalConsole` では標準入力を使えないため、 integratedTerminal を利用します。